### PR TITLE
Migrate 1.0 instruction executions to 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+.idea

--- a/src/handlers/appendFile.ts
+++ b/src/handlers/appendFile.ts
@@ -9,7 +9,7 @@ import Render from '../Render';
 const appendFile = (
   params: AppendFileInfo,
   reporter: Reporter,
-  render: Render
+  render: Render,
 ) => {
   const { from, at, context } = params;
   let { content } = params;

--- a/src/handlers/createFile.ts
+++ b/src/handlers/createFile.ts
@@ -9,7 +9,7 @@ import Render from '../Render';
 const createFile = (
   params: CreateFileInfo,
   reporter: Reporter,
-  render: Render
+  render: Render,
 ) => {
   let { content } = params;
   const { from, at, context, overwrite } = params;

--- a/src/handlers/deleteFile.ts
+++ b/src/handlers/deleteFile.ts
@@ -1,0 +1,17 @@
+import * as fs from 'fs';
+import Reporter from '../Reporter';
+import DeleteFileInfo from '../instructions/DeleteFileInfo';
+
+const deleteFile = (params: DeleteFileInfo, reporter: Reporter) => {
+  let { at } = params;
+  if (fs.existsSync(at)) {
+    // delete file
+    fs.unlinkSync(at);
+    reporter.push({ message: 'delete', file: at });
+  } else {
+    // do nothing
+    reporter.push({ message: 'not exist', file: at });
+  }
+};
+
+export default deleteFile;

--- a/src/handlers/detachFromFile.ts
+++ b/src/handlers/detachFromFile.ts
@@ -1,0 +1,42 @@
+import * as fs from 'fs';
+import isDefined from '../utilities/isDefined';
+import Render from '../Render';
+import Reporter from '../Reporter';
+import DetachFromFileInfo from '../instructions/DetachFromFileInfo';
+
+const detachFromFile = (
+  params: DetachFromFileInfo,
+  reporter: Reporter,
+  render: Render,
+) => {
+  let content = params.content;
+  const { from, at, context } = params;
+
+  if (!isDefined(from) && !isDefined(content)) {
+    throw new Error(`you should provide content or from for '${at}'.`);
+  }
+
+  if (isDefined(from)) {
+    content = fs.readFileSync(from as string).toString();
+  }
+
+  if (context) {
+    content = render(content as string, context);
+  }
+
+  if (fs.existsSync(at)) {
+    const destContent = fs.readFileSync(at).toString();
+    if (content && destContent.endsWith(content)) {
+      // remove content from the bottom
+      fs.truncateSync(at, destContent.indexOf(content));
+      reporter.push({ message: 'truncate', file: at });
+    } else {
+      // cannot remove content
+      reporter.push({ message: 'not detachable', file: at });
+    }
+  } else {
+    reporter.push({ message: 'not exist', file: at });
+  }
+};
+
+export default detachFromFile;

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,2 +1,13 @@
-export { default as appendFile } from './appendFile';
 export { default as createFile } from './createFile';
+export { default as deleteFile } from './deleteFile';
+export { default as appendFile } from './appendFile';
+export { default as detachFromFile } from './detachFromFile';
+export { default as updateFile } from './updateFile';
+export { default as rollbackFile } from './rollbackFile';
+export { default as updateJSONFile } from './updateJSONFile';
+export { default as rollbackJSONFile } from './rollbackJSONFile';
+export { default as installDependency } from './installDependency';
+export { default as removeDependency } from './removeDependency';
+export { default as keepDirectoryInGit } from './keepDirectoryInGit';
+export { default as runShellCommand } from './runShellCommand';
+export { default as undoShellCommand } from './undoShellCommand';

--- a/src/handlers/installDependency.ts
+++ b/src/handlers/installDependency.ts
@@ -1,0 +1,65 @@
+import * as fs from 'fs';
+import * as path from 'path';
+const { spawnSync } = require('child_process');
+const getDestination = require('../getDestination');
+const outputMessage = require('./outputMessage');
+
+const isDependencyInstalled = (pkgName, dev) => {
+  const pkgFile = path.join(getDestination(), 'package.json');
+  if (!fs.existsSync(pkgFile)) {
+    return false;
+  }
+  const pkg = require(pkgFile);
+  const section = dev ? pkg.devDependencies : pkg.dependencies;
+  return !!(section && section[pkgName]);
+};
+
+const mockInstallDependency = (pkgName, version, dev) => {
+  const pkgFile = path.join(getDestination(), 'package.json');
+  if (!fs.existsSync(pkgFile)) {
+    fs.writeFileSync(
+      pkgFile,
+      JSON.stringify(
+        {
+          dependencies: {},
+          devDependencies: {},
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  }
+  const pkg = require(pkgFile);
+  pkg[dev ? 'devDependencies' : 'dependencies'][pkgName] = version;
+  fs.writeFileSync(pkgFile, JSON.stringify(pkg, null, 2) + '\n');
+};
+
+const realInstallDependency = (pkgName, version, dev) => {
+  const obj = spawnSync('npm', [
+    'install',
+    pkgName + '@' + version,
+    dev ? '--save-dev' : '--save',
+  ]);
+  if (obj.signal === 'SIGINT') {
+    console.log('');
+    process.exit(0);
+  }
+};
+
+const installDependency = params => {
+  const pkgName = params.package;
+  const { version, dev, mock, silent } = params;
+  const installed = isDependencyInstalled(pkgName, dev);
+  if (installed) {
+    outputMessage('installed', 'yellow', pkgName, silent);
+  } else {
+    outputMessage('install', 'green', pkgName, silent);
+    if (mock) {
+      mockInstallDependency(pkgName, version, dev);
+    } else {
+      realInstallDependency(pkgName, version, dev);
+    }
+  }
+};
+
+export default installDependency;

--- a/src/handlers/keepDirectoryInGit.ts
+++ b/src/handlers/keepDirectoryInGit.ts
@@ -1,0 +1,34 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as mkdirp from 'mkdirp';
+import KeepDirectoryInGitInfo from '../instructions/KeepDirectoryInGitInfo';
+import Reporter from '../Reporter';
+
+const keepDirectoryInGit = (
+  params: KeepDirectoryInGitInfo,
+  reporter: Reporter,
+) => {
+  let { at } = params;
+  const keepFilename = '.keep';
+  if (fs.existsSync(at) && fs.lstatSync(at).isDirectory()) {
+    // the directory exist
+    const filenames = fs.readdirSync(at);
+    if (filenames.includes(keepFilename) && filenames.length > 1) {
+      fs.unlinkSync(path.join(at, keepFilename));
+      reporter.push({ message: 'delete', file: at });
+    } else if (filenames.length === 0) {
+      fs.writeFileSync(path.join(at, keepFilename), '');
+      reporter.push({ message: 'create', file: at });
+    }
+  } else if (fs.existsSync(at)) {
+    // the directory is a file
+    // do nothing
+  } else {
+    // the directory not exist at all
+    mkdirp.sync(at);
+    fs.writeFileSync(path.join(at, keepFilename), '');
+    reporter.push({ message: 'create', file: at });
+  }
+};
+
+export default keepDirectoryInGit;

--- a/src/handlers/removeDependency.ts
+++ b/src/handlers/removeDependency.ts
@@ -1,0 +1,45 @@
+import * as fs from 'fs';
+import * as path from 'path';
+const { spawnSync } = require('child_process');
+const getDestination = require('../getDestination');
+const outputMessage = require('./outputMessage');
+
+const isDependencyInstalled = (pkgName, dev) => {
+  const pkgFile = path.join(getDestination(), 'package.json');
+  const pkg = require(pkgFile);
+  const section = dev ? pkg.devDependencies : pkg.dependencies;
+  return !!section[pkgName];
+};
+
+const mockRemoveDependency = (pkgName, dev) => {
+  const pkgFile = path.join(getDestination(), 'package.json');
+  const pkg = require(pkgFile);
+  delete pkg[dev ? 'devDependencies' : 'dependencies'][pkgName];
+  fs.writeFileSync(pkgFile, JSON.stringify(pkg, null, 2) + '\n');
+};
+
+const realRemoveDependency = pkgName => {
+  const obj = spawnSync('npm', ['remove', pkgName]);
+  if (obj.signal === 'SIGINT') {
+    console.log('');
+    process.exit(0);
+  }
+};
+
+const removeDependency = params => {
+  const pkgName = params.package;
+  const { dev, mock, silent } = params;
+  const installed = isDependencyInstalled(pkgName, dev);
+  if (installed) {
+    outputMessage('remove', 'green', pkgName, silent);
+    if (mock) {
+      mockRemoveDependency(pkgName, dev);
+    } else {
+      realRemoveDependency(pkgName);
+    }
+  } else {
+    outputMessage('uninstalled', 'yellow', pkgName, silent);
+  }
+};
+
+export default removeDependency;

--- a/src/handlers/rollbackFile.ts
+++ b/src/handlers/rollbackFile.ts
@@ -1,0 +1,24 @@
+import * as fs from 'fs';
+import { isEqual } from 'lodash';
+import RollbackFileInfo from '../instructions/RollbackFileInfo';
+import Reporter from '../Reporter';
+
+const rollbackFile = (params: RollbackFileInfo, reporter: Reporter) => {
+  let { at, rollbacker } = params;
+
+  if (fs.existsSync(at)) {
+    const before = fs.readFileSync(at).toString();
+    const after = rollbacker(before);
+    if (isEqual(before, after)) {
+      reporter.push({ message: 'unchanged', file: at });
+    } else {
+      fs.writeFileSync(at, after);
+      reporter.push({ message: 'rollback', file: at });
+    }
+  } else {
+    // file not exist, can not rollback
+    reporter.push({ message: 'not exist', file: at });
+  }
+};
+
+export default rollbackFile;

--- a/src/handlers/rollbackJSONFile.ts
+++ b/src/handlers/rollbackJSONFile.ts
@@ -1,0 +1,24 @@
+import * as fs from 'fs';
+import { isEqual, cloneDeep } from 'lodash';
+import RollbackJSONFileInfo from '../instructions/RollbackJSONFileInfo';
+import Reporter from '../Reporter';
+
+const rollbackJSONFile = (params: RollbackJSONFileInfo, reporter: Reporter) => {
+  let { at, rollbacker } = params;
+  const dest = at;
+  if (fs.existsSync(dest)) {
+    const before = JSON.parse(fs.readFileSync(dest).toString());
+    const after = rollbacker(cloneDeep(before));
+    if (isEqual(before, after)) {
+      reporter.push({ message: 'unchanged', file: at });
+    } else {
+      fs.writeFileSync(at, JSON.stringify(after, null, 2) + '\n');
+      reporter.push({ message: 'rollback', file: at });
+    }
+  } else {
+    // file not exist, can not rollback
+    reporter.push({ message: 'not exist', file: at });
+  }
+};
+
+export default rollbackJSONFile;

--- a/src/handlers/runShellCommand.ts
+++ b/src/handlers/runShellCommand.ts
@@ -1,0 +1,26 @@
+import Reporter from '../Reporter';
+import RunShellCommandInfo from '../instructions/RunShellCommandInfo';
+
+import { promisify } from 'util';
+import { exec } from 'child_process';
+
+const execAsync = promisify(exec);
+
+const runShellCommand = async (
+  params: RunShellCommandInfo,
+  reporter: Reporter,
+) => {
+  const { command } = params;
+  reporter.push({ message: 'run', command });
+  const obj = await execAsync(command);
+
+  if (obj.stderr) {
+    process.stdout.write(obj.stdout);
+    process.stderr.write(obj.stderr);
+    reporter.push({ message: 'failed', command });
+  } else {
+    process.stdout.write(obj.stdout);
+  }
+};
+
+export default runShellCommand;

--- a/src/handlers/undoShellCommand.ts
+++ b/src/handlers/undoShellCommand.ts
@@ -1,0 +1,24 @@
+import UndoShellCommandInfo from '../instructions/UndoShellCommandInfo';
+import Reporter from '../Reporter';
+import { promisify } from 'util';
+import { exec } from 'child_process';
+
+const execAsync = promisify(exec);
+
+const undoShellCommand = async (
+  params: UndoShellCommandInfo,
+  reporter: Reporter,
+) => {
+  const { reverseCommand } = params;
+  reporter.push({ message: 'run', command: reverseCommand });
+  const obj = await execAsync(reverseCommand);
+  if (obj.stderr) {
+    process.stdout.write(obj.stdout);
+    process.stderr.write(obj.stderr);
+    reporter.push({ message: 'failed', command: reverseCommand });
+  } else {
+    process.stdout.write(obj.stdout);
+  }
+};
+
+export default undoShellCommand;

--- a/src/handlers/updateFile.ts
+++ b/src/handlers/updateFile.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as mkdirp from 'mkdirp';
+import { isEqual } from 'lodash';
+import UpdateFileInfo from '../instructions/UpdateFileInfo';
+import Reporter from '../Reporter';
+
+const updateFile = (params: UpdateFileInfo, reporter: Reporter) => {
+  let { at, updator } = params;
+
+  if (fs.existsSync(at)) {
+    const before = fs.readFileSync(at).toString();
+    const after = updator(before);
+    if (isEqual(before, after)) {
+      reporter.push({ message: 'up-to-date', file: at });
+    } else {
+      fs.writeFileSync(at, after);
+      reporter.push({ message: 'update', file: at });
+    }
+  } else {
+    mkdirp.sync(path.dirname(at));
+    fs.writeFileSync(at, updator(''));
+    reporter.push({ message: 'create', file: at });
+  }
+};
+
+export default updateFile;

--- a/src/handlers/updateJSONFile.ts
+++ b/src/handlers/updateJSONFile.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as mkdirp from 'mkdirp';
+import { isEqual, cloneDeep } from 'lodash';
+import isDefined from '../utilities/isDefined';
+import UpdateJSONFileInfo from '../instructions/UpdateJSONFileInfo';
+import Reporter from '../Reporter';
+
+const updateJSONFile = (params: UpdateJSONFileInfo, reporter: Reporter) => {
+  let { at, updator } = params;
+
+  if (!isDefined(at) && !isDefined(updator)) {
+    throw new Error(`you should provide at and updator`);
+  }
+
+  const dest = at;
+  if (fs.existsSync(dest)) {
+    const before = JSON.parse(fs.readFileSync(dest).toString());
+    const after = updator(cloneDeep(before));
+    if (isEqual(before, after)) {
+      reporter.push({ message: 'up-to-date', file: at });
+    } else {
+      fs.writeFileSync(at, JSON.stringify(after, null, 2) + '\n');
+      reporter.push({ message: 'update', file: at });
+    }
+  } else {
+    mkdirp.sync(path.dirname(dest));
+    fs.writeFileSync(at, JSON.stringify(updator({}), null, 2) + '\n');
+    reporter.push({ message: 'create', file: at });
+  }
+};
+
+export default updateJSONFile;


### PR DESCRIPTION
Remove template searching and destination resolving functions. Use plain from and at instead.
Remove call of ejs, use the render method in the argument instead. We are going to support any template engine.
Alter isUndefined with !isDefined.
Remove lodash as long as possible.
Alter message return or outputMessage with reporter.push.